### PR TITLE
Use correct talent rank.

### DIFF
--- a/src/TemplateNPC.cpp
+++ b/src/TemplateNPC.cpp
@@ -79,7 +79,7 @@ void sTemplateNPC::LearnTemplateTalents(Player* player)
         if ((*itr)->playerClass == GetClassString(player).c_str() && (*itr)->playerSpec == sTalentsSpec)
         {
             player->learnSpell((*itr)->talentId);
-            player->addTalent((*itr)->talentId, player->GetActiveSpecMask(), true);
+            player->addTalent((*itr)->talentId, player->GetActiveSpecMask(), 0);
         }
     }
 


### PR DESCRIPTION
This is to fix talents that don't have spell ranks being usable and displaying in your spell book. The argument true gets passed as a uint32 value of 1, it should be 0.

An example of this is the warrior last stand talent