### PR TITLE
fix: Areatrigger fmt shows as "{} {}"

### DIFF
--- a/src/npc_talent_template.cpp
+++ b/src/npc_talent_template.cpp
@@ -57,14 +57,12 @@ void sTemplateNPC::RemoveAllGlyphs(Player* player)
     for (uint8 i = 0; i < MAX_GLYPH_SLOT_INDEX; ++i)
         if (uint32 glyph = player->GetGlyph(i))
             if (GlyphPropertiesEntry const* gp = sGlyphPropertiesStore.LookupEntry(glyph))
-            {
                 if (GlyphSlotEntry const* gs = sGlyphSlotStore.LookupEntry(player->GetGlyphSlot(i)))
                 {
                     player->RemoveAurasDueToSpell(gp->SpellId);
                     player->SetGlyph(i, 0, true);
                     player->SendTalentsInfoData(false); // this is somewhat an in-game glyph realtime update (apply/remove)
                 }
-            }
 }
 
 void sTemplateNPC::LearnTemplateTalents(Player* player, const std::string& sTalents)

--- a/src/npc_talent_template.cpp
+++ b/src/npc_talent_template.cpp
@@ -57,7 +57,7 @@ void sTemplateNPC::RemoveAllGlyphs(Player* player)
     for (uint8 i = 0; i < MAX_GLYPH_SLOT_INDEX; ++i)
         if (uint32 glyph = player->GetGlyph(i))
             if (GlyphPropertiesEntry const* gp = sGlyphPropertiesStore.LookupEntry(glyph))
-                if (GlyphSlotEntry const* gs = sGlyphSlotStore.LookupEntry(player->GetGlyphSlot(i)))
+                if (sGlyphSlotStore.LookupEntry(player->GetGlyphSlot(i)))
                 {
                     player->RemoveAurasDueToSpell(gp->SpellId);
                     player->SetGlyph(i, 0, true);

--- a/src/npc_talent_template.cpp
+++ b/src/npc_talent_template.cpp
@@ -302,7 +302,7 @@ void sTemplateNPC::ExtractTalentTemplateToDB(Player* player, const std::string& 
 
     if (player->GetFreeTalentPoints() > 0)
     {
-        player->GetSession()->SendAreaTriggerMessage("%s", player->GetSession()->GetModuleString(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_EXTRACT_MUST_SPEND_ALL_TALENT_POINTS)->c_str());
+        player->GetSession()->SendAreaTriggerMessage(player->GetSession()->GetModuleString(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_EXTRACT_MUST_SPEND_ALL_TALENT_POINTS)->c_str());
         ChatHandler(player->GetSession()).PSendModuleSysMessage(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_EXTRACT_MUST_SPEND_ALL_TALENT_POINTS);
         return;
     }
@@ -322,7 +322,7 @@ void sTemplateNPC::ExtractGlyphsTemplateToDB(Player* player, const std::string& 
 
     if (!result)
     {
-        player->GetSession()->SendAreaTriggerMessage("%s", player->GetSession()->GetModuleString(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_EXTRACT_GET_GLYPHS)->c_str());
+        player->GetSession()->SendAreaTriggerMessage(player->GetSession()->GetModuleString(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_EXTRACT_GET_GLYPHS)->c_str());
         ChatHandler(player->GetSession()).PSendModuleSysMessage(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_EXTRACT_GET_GLYPHS);
         return;
     }
@@ -406,13 +406,13 @@ void sTemplateNPC::ApplyTemplate(Player* player, IndexTemplate* indexTemplate)
     bool canApply = true;
     if ((flag & TEMPLATE_APPLY_GEAR) && sTemplateNpcMgr->IsWearingAnyGear(player))
     {
-        player->GetSession()->SendAreaTriggerMessage("%s", player->GetSession()->GetModuleString(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_MUST_REMOVE_EQUIPPED)->c_str());
+        player->GetSession()->SendAreaTriggerMessage(player->GetSession()->GetModuleString(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_MUST_REMOVE_EQUIPPED)->c_str());
         ChatHandler(player->GetSession()).PSendModuleSysMessage(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_MUST_REMOVE_EQUIPPED);
         canApply = false;
     }
     if ((flag & TEMPLATE_APPLY_TALENTS) && sTemplateNpcMgr->HasSpentTalentPoints(player))
     {
-        player->GetSession()->SendAreaTriggerMessage("%s", player->GetSession()->GetModuleString(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_MUST_RESET_TALENTS)->c_str());
+        player->GetSession()->SendAreaTriggerMessage(player->GetSession()->GetModuleString(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_MUST_RESET_TALENTS)->c_str());
         ChatHandler(player->GetSession()).PSendModuleSysMessage(MODULE_STRING, ERROR_NPC_TALENT_TEMPLATE_MUST_RESET_TALENTS);
         canApply = false;
     }
@@ -465,7 +465,7 @@ void sTemplateNPC::ApplyTemplate(Player* player, IndexTemplate* indexTemplate)
     if (!player->HasSpell(SPELL_LEARN_A_SECOND_TALENT_SPECIALIZATION))
         player->CastSpell(player, SPELL_LEARN_A_SECOND_TALENT_SPECIALIZATION, player->GetGUID());
 
-    player->GetSession()->SendAreaTriggerMessage(player->GetSession()->GetModuleString(MODULE_STRING, SUCCESS_NPC_TALENT_TEMPLATE_EQUIPPED_TEMPLATE)->c_str(), sTemplateNpcMgr->GetClassString(player).c_str(), indexTemplate->playerSpec.c_str());
+    player->GetSession()->SendAreaTriggerMessage(player->GetSession()->GetModuleString(MODULE_STRING, SUCCESS_NPC_TALENT_TEMPLATE_EQUIPPED_TEMPLATE)->c_str(), sTemplateNpcMgr->GetClassString(player), indexTemplate->playerSpec);
 }
 
 class npc_talent_template : public CreatureScript
@@ -525,7 +525,7 @@ public:
 
             case GOSSIP_ACTION_RESET_REMOVE_GLYPHS:
                 sTemplateNpcMgr->RemoveAllGlyphs(player);
-                player->GetSession()->SendAreaTriggerMessage("%s", player->GetSession()->GetModuleString(MODULE_STRING, SUCCESS_NPC_TALENT_TEMPLATE_REMOVED_GLYPHS)->c_str());
+                player->GetSession()->SendAreaTriggerMessage(player->GetSession()->GetModuleString(MODULE_STRING, SUCCESS_NPC_TALENT_TEMPLATE_REMOVED_GLYPHS)->c_str());
                 CloseGossipMenuFor(player);
                 break;
 
@@ -552,7 +552,7 @@ public:
                     player->DestroyItem(INVENTORY_SLOT_BAG_0, i, true);
                 }
                 player->SaveToDB(false, false);
-                player->GetSession()->SendAreaTriggerMessage("%s", player->GetSession()->GetModuleString(MODULE_STRING, SUCCESS_NPC_TALENT_TEMPLATE_DESTROYED_EQUIPPED_GEAR)->c_str());
+                player->GetSession()->SendAreaTriggerMessage(player->GetSession()->GetModuleString(MODULE_STRING, SUCCESS_NPC_TALENT_TEMPLATE_DESTROYED_EQUIPPED_GEAR)->c_str());
                 CloseGossipMenuFor(player);
                 break;
 
@@ -599,7 +599,7 @@ public:
         sTemplateNpcMgr->ExtractTalentTemplateToDB(player, specName);
         sTemplateNpcMgr->ExtractGlyphsTemplateToDB(player, specName);
         sTemplateNpcMgr->InsertIndexEntryToDB(player, specName);
-        player->GetSession()->SendAreaTriggerMessage("%s", player->GetSession()->GetModuleString(MODULE_STRING, SUCCESS_NPC_TALENT_TEMPLATE_EXTRACT)->c_str());
+        player->GetSession()->SendAreaTriggerMessage(player->GetSession()->GetModuleString(MODULE_STRING, SUCCESS_NPC_TALENT_TEMPLATE_EXTRACT)->c_str());
         ChatHandler(player->GetSession()).PSendModuleSysMessage(MODULE_STRING, SUCCESS_NPC_TALENT_TEMPLATE_EXTRACT_INFO);
         return true;
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
fix TODO "areatrigger fmt shows as "{} {}"
- https://github.com/azerothcore/mod-npc-talent-template/pull/51


requires at least acore:
- https://github.com/azerothcore/azerothcore-wotlk/commit/25fb6cca47f43e12c154db6d886d792629a5befb

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- tested ingame
- 

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
